### PR TITLE
Have 8 SG rounds before restart

### DIFF
--- a/servers/SG01.yml
+++ b/servers/SG01.yml
@@ -3,6 +3,11 @@ minimum: 0.33
 maximum: 1.2
 maps:
 - LobbySG
+- LobbySG
+- LobbySG
+- LobbySG
+- LobbySG
+- LobbySG
 selection:
 - SurvivalGames2
 - SurvivalGames1

--- a/servers/SG01.yml
+++ b/servers/SG01.yml
@@ -8,6 +8,8 @@ maps:
 - LobbySG
 - LobbySG
 - LobbySG
+- LobbySG
+- LobbySG
 selection:
 - SurvivalGames2
 - SurvivalGames1

--- a/servers/SG02.yml
+++ b/servers/SG02.yml
@@ -3,6 +3,13 @@ minimum: 0.33
 maximum: 1.2
 maps:
 - LobbySG
+- LobbySG
+- LobbySG
+- LobbySG
+- LobbySG
+- LobbySG
+- LobbySG
+- LobbySG
 selection:
 - SurvivalGames2
 - SurvivalGames1

--- a/servers/SG03.yml
+++ b/servers/SG03.yml
@@ -3,6 +3,13 @@ minimum: 0.33
 maximum: 1.2
 maps:
 - LobbySG
+- LobbySG
+- LobbySG
+- LobbySG
+- LobbySG
+- LobbySG
+- LobbySG
+- LobbySG
 selection:
 - SurvivalGames2
 - SurvivalGames1


### PR DESCRIPTION
For servers SG01, SG02 & SG03

Been playing a bit of SG today and I've asked people on the server and multiple SG rounds is something we would really like to see. As it's really annoying having to switch servers all the time after every single game and people will be likely to play more of it and the amount of people playing will be higher as the server can build up over a longer period of time instead of just 60 seconds, therefore making games better and more varied 