### PR TITLE
Fix spacing in Hardcore Games title

### DIFF
--- a/servers/HG01.yml
+++ b/servers/HG01.yml
@@ -1,4 +1,4 @@
 minimum: 0.10
 maximum: 1.2
 maps:
-- HardcoreGames
+- Hardcore Games


### PR DESCRIPTION
Maybe this could be why HG was down... in maps.avicus.net (see http://maps.avicus.net/Hardcore%20Games/) it's a space included between. May fix HG01.