### PR TITLE
Remove ClayTDM and Spookghetto

### DIFF
--- a/servers/TDM01.yml
+++ b/servers/TDM01.yml
@@ -3,8 +3,6 @@ maximum: 1.2
 maps:
 - Zao
 - Mirage
-- ClayTDM
-- Spookghetto
 - IllegalOffice
 - Periculum
 - Raptors


### PR DESCRIPTION
Spookghetto does not play well. Tons of random soul sand, cobwebs, and the center is a pain to boat through if you don't want to be shot or tapped with the axe. It's one of the few one hit kill maps left, and it's not the funnest of them all to keep. It's a pain to navigate.

ClayTDM is too flat and was removed a while ago. The gameplay is stale and it's not very fun.