### PR TITLE
Replace Victory with Mute City 2

### DIFF
--- a/servers/Destroy.xml
+++ b/servers/Destroy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rotation>
-    <map>Victory</map>
+    <map>Mute City 2</map>
     <map>Formorgar 2</map>
     <map>Unix</map>
     <map>Proelium1.5</map>


### PR DESCRIPTION
Victory is a really bad map, it is actually kind of embarrassing.

Everything's out of place. The front lines are literally just pill-shaped and it is quite ugly. Blocks don't match, the structures are completely unnatural, there is no theme: the split off staircase by the fountain is the most unnatural thing I've ever seen and it is not fun to play either. The map plays the same each time and there's nothing interesting to do in it. 

Cobwebs? Parkour? Random water ponds? I don't understand. I would much prefer playing Mute City 2 or one of the mute cities rather than playing this, because in all honesty I don't see how this was added to the repo.